### PR TITLE
시작하기 버튼 레이아웃 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,5 +7,5 @@ import 'src/settings/settings_service.dart';
 void main() async {
   final settingsController = SettingsController(SettingsService());
   await settingsController.loadSettings();
-  runApp(MyApp());
+  runApp(const MyApp());
 }

--- a/lib/pages/home/my_home.dart
+++ b/lib/pages/home/my_home.dart
@@ -2,18 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:puppycode/pages/setting.dart';
 import 'package:get/get.dart';
 
-class HomePage extends StatelessWidget {
-  const HomePage({ super.key });
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Home Page'),
+        title: const Text('My Home'),
       ),
       body: Center(
           child: TextButton(
-        child: const Text('go to setting'),
+        child: const Text('마이홈입니당'),
         onPressed: () {
           Get.to(() => const SettingPage());
         },

--- a/lib/pages/onboarding/landing.dart
+++ b/lib/pages/onboarding/landing.dart
@@ -9,7 +9,7 @@ class LandingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Landing Page'),
+        title: const Text('어서오시오'),
       ),
       body: Center(
           child: TextButton(
@@ -24,9 +24,9 @@ class LandingPage extends StatelessWidget {
         child: const Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SignupButton(text: '카카오로 시작하기'),
+            SignupButton(text: '카카오로 시작하기', type: SignupType.kakao),
             SizedBox(height: 12),
-            SignupButton(text: 'Continue with Apple')
+            SignupButton(text: 'Continue with Apple', type: SignupType.apple)
           ],
         ),
       ),
@@ -34,27 +34,34 @@ class LandingPage extends StatelessWidget {
   }
 }
 
+enum SignupType { kakao, apple }
+
 class SignupButton extends StatelessWidget {
   const SignupButton({
     required this.text,
+    required this.type,
     super.key,
   });
 
   final String text;
+  final SignupType type;
 
   @override
   Widget build(BuildContext context) {
     return Flexible(
-      //height: 45,
       child: TextButton(
         onPressed: () => {},
         style: TextButton.styleFrom(
-            backgroundColor: Colors.yellow,
+            backgroundColor:
+                type == SignupType.kakao ? Colors.yellow : Colors.black,
             shape: const RoundedRectangleBorder(
                 borderRadius: BorderRadius.all(Radius.circular(5)))),
         child: Text(
           text,
-          style: const TextStyle(fontSize: 14.5, color: Colors.black),
+          style: TextStyle(
+            fontSize: 14.5,
+            color: type == SignupType.kakao ? Colors.black : Colors.white,
+          ),
         ),
       ),
     );

--- a/lib/pages/onboarding/landing.dart
+++ b/lib/pages/onboarding/landing.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:puppycode/pages/onboarding/name_input.dart';
+import 'package:get/get.dart';
+
+class LandingPage extends StatelessWidget {
+  const LandingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Landing Page'),
+      ),
+      body: Center(
+          child: TextButton(
+        child: const Text('register'),
+        onPressed: () {
+          Get.to(() => const NameInputPage());
+        },
+      )),
+      bottomSheet: Container(
+        constraints: const BoxConstraints(maxHeight: 102),
+        margin: const EdgeInsets.fromLTRB(45, 0, 45, 75),
+        child: const Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SignupButton(text: '카카오로 시작하기'),
+            SizedBox(height: 12),
+            SignupButton(text: 'Continue with Apple')
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SignupButton extends StatelessWidget {
+  const SignupButton({
+    required this.text,
+    super.key,
+  });
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Flexible(
+      //height: 45,
+      child: TextButton(
+        onPressed: () => {},
+        style: TextButton.styleFrom(
+            backgroundColor: Colors.yellow,
+            shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(5)))),
+        child: Text(
+          text,
+          style: const TextStyle(fontSize: 14.5, color: Colors.black),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/name_input.dart
+++ b/lib/pages/onboarding/name_input.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:puppycode/pages/onboarding/start.dart';
 import 'package:puppycode/shared/styles/button.dart';
 import 'package:get/get.dart';
 
@@ -15,7 +16,7 @@ class _NameInputPageState extends State<NameInputPage> {
 
   validateName() {
     setState(() {
-      isValidName = name.length > 5;
+      isValidName = name.length > 2;
     });
   }
 
@@ -118,7 +119,7 @@ class _NameConfirmButtonState extends State<NameConfirmButton> {
         flex: 2,
         child: DefaultTextButton(
           text: '등록하기',
-          onPressed: () => {},
+          onPressed: () => {Get.to(() => const StartPage())},
           disabled: !widget.isActive,
         ));
   }

--- a/lib/pages/onboarding/start.dart
+++ b/lib/pages/onboarding/start.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class StartPage extends StatelessWidget {
+  const StartPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+          child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            '개떡이와 오늘도\n산책하러 갈까요?',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                color: Colors.black, fontSize: 24, fontWeight: FontWeight.w600),
+          ),
+          TextButton(
+              onPressed: () => {Get.toNamed('/home')},
+              child: const Text('피드로 ㄱㄱ'))
+        ],
+      )),
+    );
+  }
+}

--- a/lib/pages/route.dart
+++ b/lib/pages/route.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:puppycode/pages/home.dart';
+import 'package:puppycode/pages/home/my_home.dart';
 import 'package:puppycode/pages/onboarding/index.dart';
 import 'package:puppycode/pages/onboarding/landing.dart';
 import 'package:puppycode/pages/setting.dart';
@@ -10,5 +11,6 @@ class AppRoutes {
     GetPage(name: '/settings', page: () => const SettingPage()),
     GetPage(name: '/onboarding', page: () => const LandingPage()),
     GetPage(name: '/onboarding/name', page: () => const OnboardingPage()),
+    GetPage(name: '/home', page: () => const MyHomePage()),
   ];
 }

--- a/lib/pages/route.dart
+++ b/lib/pages/route.dart
@@ -1,12 +1,14 @@
 import 'package:get/get.dart';
 import 'package:puppycode/pages/home.dart';
 import 'package:puppycode/pages/onboarding/index.dart';
+import 'package:puppycode/pages/onboarding/landing.dart';
 import 'package:puppycode/pages/setting.dart';
 
 class AppRoutes {
   static final routes = [
     GetPage(name: '/', page: () => const HomePage()),
-    GetPage(name: '/settings', page: () => SettingPage()),
+    GetPage(name: '/settings', page: () => const SettingPage()),
+    GetPage(name: '/onboarding', page: () => const LandingPage()),
     GetPage(name: '/onboarding/name', page: () => const OnboardingPage()),
   ];
 }

--- a/lib/pages/setting.dart
+++ b/lib/pages/setting.dart
@@ -34,7 +34,7 @@ class _SettingPageState extends State<SettingPage> {
                   icon: Icons.info_outline,
                   widget: GestureDetector(
                     onTap: () {
-                      Get.to(() => HomePage());
+                      Get.to(() => const HomePage());
                     },
                     child: const Icon(
                       Icons.arrow_forward_ios,
@@ -52,7 +52,7 @@ class _SettingPageState extends State<SettingPage> {
                   icon: Icons.person,
                   widget: GestureDetector(
                     onTap: () {
-                      Get.to(() => HomePage());
+                      Get.to(() => const HomePage());
                     },
                     child: const Icon(
                       Icons.arrow_forward_ios,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -10,7 +10,9 @@ class MyApp extends StatelessWidget {
     return GetMaterialApp(
       theme: ThemeData(
         scaffoldBackgroundColor: Colors.white,
-        appBarTheme: const AppBarTheme(backgroundColor: Colors.white)
+        appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
+        bottomSheetTheme:
+            const BottomSheetThemeData(backgroundColor: Colors.white),
       ),
       initialRoute: '/',
       getPages: AppRoutes.routes,


### PR DESCRIPTION
### Onboarding

- route: `/onboarding`

<img width="300" alt="image" src="https://github.com/user-attachments/assets/162deac4-09a2-4cc1-8bb9-e03a860a8ca8">

### Start

- route 따로 지정은 안함. name으로 이동할 경우는 없을 것 같음
- 추후 가입 완료되면 이전으로 돌아가지 못하게 리다이렉트해주어야 함
- 피드 버튼 클릭 시 마이 홈으로 이동하게 함

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8cb04874-29da-4013-a4fc-800a020b6867">

