### PR TITLE
유저 정보 페이지 추가

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - share (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - share (from `.symlinks/plugins/share/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  share:
+    :path: ".symlinks/plugins/share/ios"
+
+SPEC CHECKSUMS:
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  share: 0b2c3e82132f5888bccca3351c504d0003b3b410
+
+PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+
+COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		233507049D3AB6723A50503E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01028301DA4B34623FDB2104 /* Pods_Runner.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		EBBE969E0A81243DBA8842B6 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBC9BEB3897CA934C83F344C /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,14 +42,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01028301DA4B34623FDB2104 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		021C07AB81F926EC4D7D926D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2043DA027A953BDFC4296B3E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3506EB81B252E3913CFF07F9 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		54F2C8544CF9CF1E269185B0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6C1977C8B29F29D4CF5C3A50 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8AC001155CD85E1CD1D469BB /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +64,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CBC9BEB3897CA934C83F344C /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +72,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				233507049D3AB6723A50503E /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B142B882FE60A7A43FF2E8A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBBE969E0A81243DBA8842B6 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +113,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				E16058D058E37B1C43243FB7 /* Pods */,
+				F85DD5B7C1E56D23773F6371 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +142,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		E16058D058E37B1C43243FB7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2043DA027A953BDFC4296B3E /* Pods-Runner.debug.xcconfig */,
+				6C1977C8B29F29D4CF5C3A50 /* Pods-Runner.release.xcconfig */,
+				3506EB81B252E3913CFF07F9 /* Pods-Runner.profile.xcconfig */,
+				54F2C8544CF9CF1E269185B0 /* Pods-RunnerTests.debug.xcconfig */,
+				8AC001155CD85E1CD1D469BB /* Pods-RunnerTests.release.xcconfig */,
+				021C07AB81F926EC4D7D926D /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		F85DD5B7C1E56D23773F6371 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				01028301DA4B34623FDB2104 /* Pods_Runner.framework */,
+				CBC9BEB3897CA934C83F344C /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				AFA96256441821BB15E14010 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				B142B882FE60A7A43FF2E8A2 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				0817D5CD1202292CDE8AC3E7 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				A3B6EFDB5C3A60CCD5C476C4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +270,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0817D5CD1202292CDE8AC3E7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +322,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		A3B6EFDB5C3A60CCD5C476C4 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AFA96256441821BB15E14010 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 54F2C8544CF9CF1E269185B0 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8AC001155CD85E1CD1D469BB /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 021C07AB81F926EC4D7D926D /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:puppycode/pages/setting.dart';
+import 'package:puppycode/pages/setting/setting.dart';
 import 'package:get/get.dart';
 
 class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -13,7 +15,7 @@ class HomePage extends StatelessWidget {
           child: TextButton(
         child: const Text('go to setting'),
         onPressed: () {
-          Get.to(() => SettingPage());
+          Get.to(() => const SettingPage());
         },
       )),
     );

--- a/lib/pages/onboarding.dart
+++ b/lib/pages/onboarding.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:puppycode/pages/setting.dart';
+import 'package:puppycode/pages/setting/setting.dart';
 import 'package:get/get.dart';
 
 class OnboardingPage extends StatelessWidget {
@@ -15,7 +15,7 @@ class OnboardingPage extends StatelessWidget {
           child: TextButton(
         child: const Text('go to setting'),
         onPressed: () {
-          Get.to(() => SettingPage());
+          Get.to(() => const SettingPage());
         },
       )),
     );

--- a/lib/pages/route.dart
+++ b/lib/pages/route.dart
@@ -1,12 +1,14 @@
 import 'package:get/get.dart';
 import 'package:puppycode/pages/home.dart';
 import 'package:puppycode/pages/onboarding.dart';
-import 'package:puppycode/pages/setting.dart';
+import 'package:puppycode/pages/setting/setting.dart';
+import 'package:puppycode/pages/setting/user_info.dart';
 
 class AppRoutes {
   static final routes = [
-    GetPage(name: '/', page: () => HomePage()),
-    GetPage(name: '/settings', page: () => SettingPage()),
+    GetPage(name: '/', page: () => const HomePage()),
+    GetPage(name: '/settings', page: () => const SettingPage()),
     GetPage(name: '/onboarding/name', page: () => const OnboardingPage()),
+    GetPage(name: '/settings/userInfo', page: () => const UserInfoPage()),
   ];
 }

--- a/lib/pages/setting/setting.dart
+++ b/lib/pages/setting/setting.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:puppycode/pages/home.dart';
+import 'package:puppycode/pages/setting/user_info.dart';
 
 class SettingPage extends StatefulWidget {
   const SettingPage({super.key});
@@ -28,36 +29,29 @@ class _SettingPageState extends State<SettingPage> {
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
           child: Column(
             children: [
-              SettingList(lists: [
+              const SettingList(lists: [
                 SettingListItem(
                   title: '내 정보',
                   icon: Icons.info_outline,
-                  widget: GestureDetector(
-                    onTap: () {
-                      Get.to(() => HomePage());
-                    },
-                    child: const Icon(
-                      Icons.arrow_forward_ios,
-                      size: 16,
-                    ),
+                  destination: '/settings/userInfo',
+                  widget: Icon(
+                    Icons.arrow_forward_ios,
+                    size: 16,
                   ),
                 ),
-                const SettingListItem(
+                SettingListItem(
                   title: '내 초대링크',
                   icon: Icons.link,
                   widget: null,
+                  destination: '',
                 ),
                 SettingListItem(
                   title: '친구리스트',
                   icon: Icons.person,
-                  widget: GestureDetector(
-                    onTap: () {
-                      Get.to(() => HomePage());
-                    },
-                    child: const Icon(
-                      Icons.arrow_forward_ios,
-                      size: 16,
-                    ),
+                  destination: '/settings/userInfo',
+                  widget: Icon(
+                    Icons.arrow_forward_ios,
+                    size: 16,
                   ),
                 ),
               ], title: '내 정보'),
@@ -65,6 +59,7 @@ class _SettingPageState extends State<SettingPage> {
                 SettingListItem(
                   title: '알림',
                   icon: Icons.notifications,
+                  destination: '',
                   widget: CupertinoSwitch(
                     value: switchValue,
                     onChanged: onSwitchPressed,
@@ -73,6 +68,7 @@ class _SettingPageState extends State<SettingPage> {
                 const SettingListItem(
                   title: '시간설정',
                   icon: Icons.timer,
+                  destination: '',
                   widget: Text(
                     '00:00',
                     style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
@@ -83,6 +79,7 @@ class _SettingPageState extends State<SettingPage> {
                 SettingListItem(
                   title: '앱 정보',
                   icon: Icons.info_rounded,
+                  destination: '',
                   widget: Text(
                     '현재 버전 1.0.0',
                     style: TextStyle(fontSize: 14, fontWeight: FontWeight.w300),
@@ -91,16 +88,19 @@ class _SettingPageState extends State<SettingPage> {
                 SettingListItem(
                   title: '이용약관',
                   icon: Icons.link,
+                  destination: '',
                   widget: null,
                 ),
                 SettingListItem(
                   title: '개인정보 처리방침',
                   icon: Icons.person,
+                  destination: '',
                   widget: null,
                 ),
                 SettingListItem(
                   title: '계정관리',
                   icon: Icons.person,
+                  destination: '',
                   widget: null,
                 ),
               ], title: '도움말'),
@@ -160,6 +160,7 @@ class SettingList extends StatelessWidget {
 class SettingListItem extends StatelessWidget {
   final String title;
   final IconData icon;
+  final String? destination;
   final Widget? widget;
 
   const SettingListItem({
@@ -167,34 +168,41 @@ class SettingListItem extends StatelessWidget {
     required this.title,
     required this.icon,
     required this.widget,
+    required this.destination,
   });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       height: 50,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Icon(icon),
-              const SizedBox(
-                width: 8,
-              ),
-              Text(
-                title,
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w600,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          destination != '' ? Get.toNamed(destination!) : '';
+        },
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Icon(icon),
+                const SizedBox(
+                  width: 8,
                 ),
-              ),
-            ],
-          ),
-          SizedBox(
-            child: widget,
-          )
-        ],
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(
+              child: widget,
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/setting/setting.dart
+++ b/lib/pages/setting/setting.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:puppycode/pages/home.dart';
-import 'package:puppycode/pages/setting/user_info.dart';
 
 class SettingPage extends StatefulWidget {
   const SettingPage({super.key});

--- a/lib/pages/setting/setting.dart
+++ b/lib/pages/setting/setting.dart
@@ -21,7 +21,10 @@ class _SettingPageState extends State<SettingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+      ),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -176,7 +179,7 @@ class SettingListItem extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () {
-          destination != '' ? Get.toNamed(destination!) : '';
+          if (destination != '') Get.toNamed(destination!);
         },
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/pages/setting/user_info.dart
+++ b/lib/pages/setting/user_info.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class UserInfoPage extends StatefulWidget {
+  const UserInfoPage({super.key});
+
+  @override
+  State<UserInfoPage> createState() => _UserInfoPageState();
+}
+
+class _UserInfoPageState extends State<UserInfoPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('내 정보'), // 왼쪽 정렬이 완벽하게 안됨
+        centerTitle: false,
+      ),
+      body: const Column(
+        children: [
+          Text('앙꼬'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/setting/user_info.dart
+++ b/lib/pages/setting/user_info.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share/share.dart';
 
 class UserInfoPage extends StatefulWidget {
   const UserInfoPage({super.key});
@@ -8,6 +9,8 @@ class UserInfoPage extends StatefulWidget {
 }
 
 class _UserInfoPageState extends State<UserInfoPage> {
+  String code = 'agn35gk94';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -48,17 +51,17 @@ class _UserInfoPageState extends State<UserInfoPage> {
                   style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
                 ),
                 TextButton(
-                  onPressed: () => {},
+                  onPressed: () => {Share.share(code)},
                   style: ButtonStyle(
                       backgroundColor:
                           WidgetStateProperty.all<Color>(Colors.grey)),
-                  child: const Row(
+                  child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        '@유저네임고유코드',
+                        '@$code',
                       ),
-                      Icon(Icons.share_rounded)
+                      const Icon(Icons.share_rounded)
                     ],
                   ),
                 ),

--- a/lib/pages/setting/user_info.dart
+++ b/lib/pages/setting/user_info.dart
@@ -14,7 +14,9 @@ class _UserInfoPageState extends State<UserInfoPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
+        backgroundColor: Colors.white,
         title: const Text(
           '내 정보',
           style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),

--- a/lib/pages/setting/user_info.dart
+++ b/lib/pages/setting/user_info.dart
@@ -12,12 +12,66 @@ class _UserInfoPageState extends State<UserInfoPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('내 정보'), // 왼쪽 정렬이 완벽하게 안됨
+        title: const Text(
+          '내 정보',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+        ), // 왼쪽 정렬이 완벽하게 안됨 어케함쇼
         centerTitle: false,
       ),
-      body: const Column(
+      body: Column(
         children: [
-          Text('앙꼬'),
+          const SizedBox(
+            height: 12,
+          ),
+          Center(
+            child: Column(
+              children: [
+                Container(
+                  height: 128,
+                  width: 128,
+                  decoration: BoxDecoration(
+                      color: Colors.grey,
+                      borderRadius: BorderRadius.circular(100)),
+                ),
+                Transform.translate(
+                  offset: const Offset(40, -35),
+                  child: FloatingActionButton(
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(100)),
+                    onPressed: () => {},
+                    mini: true,
+                    child: const Icon(Icons.add),
+                  ),
+                ),
+                const Text(
+                  '앙꼬',
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                ),
+                TextButton(
+                  onPressed: () => {},
+                  style: ButtonStyle(
+                      backgroundColor:
+                          WidgetStateProperty.all<Color>(Colors.grey)),
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '@유저네임고유코드',
+                      ),
+                      Icon(Icons.share_rounded)
+                    ],
+                  ),
+                ),
+                const SizedBox(
+                  height: 30,
+                ),
+                Container(
+                  height: 8,
+                  decoration: const BoxDecoration(color: Colors.grey),
+                )
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,6 +144,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -152,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  share:
+    dependency: "direct main"
+    description:
+      name: share
+      sha256: "97e6403f564ed1051a01534c2fc919cb6e40ea55e60a18ec23cee6e0ce19f4be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   get:
+  share:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 추가/수정한 기능 설명
### 설정 페이지 수정
- 설정페이지 목록 버튼으로 모두 바꿨습니다
- GestureDetector로 했고, 빈 공간 터치는 `behavior: HitTestBehavior.opaque,`로 설정했더니 됐슴다

### 유저 정보 페이지
- share 의존성 추가했어요
- 시안 확정되면 아마 다시 손봐야할듯..

### route
- `/settings`
- `/settings/userInfo`

### 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2024-07-30 at 17 43 00](https://github.com/user-attachments/assets/f8972754-fbad-4f8c-95db-764ac8d962c3)   ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-30 at 17 43 34](https://github.com/user-attachments/assets/adc7aec2-9b8f-4297-b785-de19eaaf3d43)
