### PR TITLE
온보딩 이름 필드 추가 + 컬러칩 추가

### DIFF
--- a/assets/icons/clear.svg
+++ b/assets/icons/clear.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#EFF2F5"/>
+<path d="M8 8L16 16" stroke="#8D959A" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M8.00003 15.9999L15.9999 7.99999" stroke="#8D959A" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/lib/pages/feeds/feed_friends.dart
+++ b/lib/pages/feeds/feed_friends.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:puppycode/shared/styles/color.dart';
 import 'package:puppycode/shared/typography/body.dart';
 
 class FeedFriends extends StatelessWidget {
@@ -70,7 +71,7 @@ class FeedUserStatus extends StatelessWidget {
                 decoration: BoxDecoration(
                   color: const Color(0xFFEFF2F5),
                   border: isFocused
-                      ? Border.all(color: const Color(0xFF36DBBF), width: 2)
+                      ? Border.all(color: ThemeColor.primary, width: 2)
                       : null,
                   borderRadius: BorderRadius.circular(16),
                 ),
@@ -141,7 +142,7 @@ class FeedFriendIcon extends StatelessWidget {
             )
           ],
           shape: BoxShape.circle,
-          color: hasWalked ? const Color(0xFF36DBBF) : Colors.white),
+          color: hasWalked ? ThemeColor.primary : ThemeColor.white),
       child: SvgPicture.asset(
         hasWalked ? 'assets/icons/paw_small.svg' : 'assets/icons/push.svg',
       ),

--- a/lib/pages/feeds/write.dart
+++ b/lib/pages/feeds/write.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:puppycode/pages/feeds/success.dart';
 import 'package:puppycode/shared/photo_item.dart';
 import 'package:puppycode/shared/styles/button.dart';
+import 'package:puppycode/shared/styles/color.dart';
 import 'package:puppycode/shared/typography/body.dart';
 
 class FeedWritePage extends StatefulWidget {
@@ -121,7 +122,6 @@ class OptionButton extends StatelessWidget {
   final bool isSelected;
   static const _borderColor = Color(0xFFE4EAEE);
   static const _textColor = Color(0xFF72757A);
-  static const _selectBorderColor = Color(0xFF36DBBF);
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +129,7 @@ class OptionButton extends StatelessWidget {
       style: OutlinedButton.styleFrom(
           padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 26),
           side:
-              BorderSide(color: isSelected ? _selectBorderColor : _borderColor),
+              BorderSide(color: isSelected ? ThemeColor.primary : _borderColor),
           shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(Radius.circular(16)))),
       onPressed: onPressed,

--- a/lib/pages/onboarding/index.dart
+++ b/lib/pages/onboarding/index.dart
@@ -7,7 +7,7 @@ class OnboardingPage extends StatelessWidget {
   // TODO: 추후 페이지 구현 다 하면 수정함
   @override
   Widget build(BuildContext context) {
-    return const NameInputPage();
+    return const RegistrationPage();
   }
 }
 

--- a/lib/pages/onboarding/index.dart
+++ b/lib/pages/onboarding/index.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:puppycode/pages/onboarding/name_input.dart';
+import 'package:puppycode/pages/onboarding/register.dart';
 
 class OnboardingPage extends StatelessWidget {
   const OnboardingPage({super.key});

--- a/lib/pages/onboarding/landing.dart
+++ b/lib/pages/onboarding/landing.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:puppycode/pages/onboarding/name_input.dart';
+import 'package:puppycode/pages/onboarding/register.dart';
 import 'package:get/get.dart';
 
 class LandingPage extends StatelessWidget {

--- a/lib/pages/onboarding/landing.dart
+++ b/lib/pages/onboarding/landing.dart
@@ -15,7 +15,7 @@ class LandingPage extends StatelessWidget {
           child: TextButton(
         child: const Text('register'),
         onPressed: () {
-          Get.to(() => const NameInputPage());
+          Get.to(() => const RegistrationPage());
         },
       )),
       bottomSheet: Container(

--- a/lib/pages/onboarding/name_input.dart
+++ b/lib/pages/onboarding/name_input.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:puppycode/pages/onboarding/start.dart';
 import 'package:puppycode/shared/styles/button.dart';
 import 'package:get/get.dart';
+import 'package:puppycode/shared/typography/body.dart';
+import 'package:puppycode/shared/typography/head.dart';
 
 class NameInputPage extends StatefulWidget {
   const NameInputPage({ super.key });
@@ -83,17 +85,16 @@ class NameGuide extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(0, 0, 0, 64),
-      child: const Column(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '우리집 강아지 이름을\n설정해볼까요?',
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 25),
-          ),
-          Text('키우는 강아지가 없어도 괜찮아요',
-              style: TextStyle(
-                  fontWeight: FontWeight.w500,
-                  color: Colors.grey,
-                  fontSize: 16))
+          const Head2(value: '우리 집 강아지의 이름과\n사는 곳을 설정해 볼까요?'),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Body2(
+                value: '키우는 강아지가 없어도 괜찮아요',
+                color: Colors.black.withOpacity(0.6)),
+          )
         ],
       ),
     );

--- a/lib/pages/onboarding/name_input.dart
+++ b/lib/pages/onboarding/name_input.dart
@@ -32,7 +32,7 @@ class _NameInputPageState extends State<NameInputPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const NameGuide(),
+            const GuideText(),
             TextField(
               onChanged: (value) {
                 setState(() {
@@ -76,8 +76,8 @@ class _NameInputPageState extends State<NameInputPage> {
   }
 }
 
-class NameGuide extends StatelessWidget {
-  const NameGuide({
+class GuideText extends StatelessWidget {
+  const GuideText({
     super.key,
   });
 
@@ -92,8 +92,7 @@ class NameGuide extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.only(top: 8),
             child: Body2(
-                value: '키우는 강아지가 없어도 괜찮아요',
-                color: Colors.black.withOpacity(0.6)),
+                value: '키우는 강아지가 없어도 괜찮아요.', color: Color(0xFF50555C)),
           )
         ],
       ),

--- a/lib/pages/onboarding/name_input.dart
+++ b/lib/pages/onboarding/name_input.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:puppycode/pages/onboarding/start.dart';
+import 'package:puppycode/shared/input.dart';
 import 'package:puppycode/shared/styles/button.dart';
 import 'package:get/get.dart';
-import 'package:puppycode/shared/styles/color.dart';
 import 'package:puppycode/shared/typography/body.dart';
 import 'package:puppycode/shared/typography/head.dart';
 
@@ -14,26 +14,10 @@ class RegistrationPage extends StatefulWidget {
 }
 
 class _RegistrationPageState extends State<RegistrationPage> {
-  String name = '';
-  bool isValidName = false;
-
-  validateName() {
-    setState(() {
-      isValidName = name.length > 2;
-    });
-  }
-
-  _getInputBorderStyle(bool focus) {
-    return OutlineInputBorder(
-      borderSide:
-          BorderSide(color: focus ? ThemeColor.primary : ThemeColor.gray2),
-      borderRadius: BorderRadius.circular(20),
-    );
-  }
+  final _nameController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(),
@@ -43,22 +27,12 @@ class _RegistrationPageState extends State<RegistrationPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const GuideText(),
-            TextField(
-              onChanged: (value) {
-                setState(() {
-                  name = value;
-                  validateName();
-                });
-              },
-              decoration: InputDecoration(
-                hintText: '강아지 이름',
-                focusedBorder: _getInputBorderStyle(true),
-                enabledBorder: _getInputBorderStyle(false),
-                contentPadding: const EdgeInsets.all(16),
-                labelStyle: BodyTextStyle.getBody1Style(bold: true),
-                hintStyle: BodyTextStyle.getBody1Style(color: ThemeColor.gray4),
-              ),
+            TextInput(
+              controller: _nameController,
+              hintText: '강아지 이름',
             ),
+            const SizedBox(height: 12),
+            // 지역 INPUT
           ],
         ),
       ),
@@ -67,17 +41,12 @@ class _RegistrationPageState extends State<RegistrationPage> {
         margin: const EdgeInsets.fromLTRB(0, 0, 0, 50),
         padding: const EdgeInsets.symmetric(horizontal: 20),
         child: Row(
-          //mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Expanded(
-              flex: 1,
-              child: DefaultTextButton(
-                text: '안할래요',
-                onPressed: () => Get.back(),
-              ),
-            ),
-            const SizedBox(width: 17),
-            NameConfirmButton(isActive: isValidName),
+                child: DefaultTextButton(
+              text: '등록하기',
+              onPressed: () => {Get.to(() => const StartPage())},
+            )),
           ],
         ),
       ),
@@ -105,30 +74,5 @@ class GuideText extends StatelessWidget {
         ],
       ),
     );
-  }
-}
-
-class NameConfirmButton extends StatefulWidget {
-  final bool isActive;
-
-  const NameConfirmButton({
-    required this.isActive,
-    super.key,
-  });
-
-  @override
-  State<NameConfirmButton> createState() => _NameConfirmButtonState();
-}
-
-class _NameConfirmButtonState extends State<NameConfirmButton> {
-  @override
-  Widget build(BuildContext context) {
-    return Expanded(
-        flex: 2,
-        child: DefaultTextButton(
-          text: '등록하기',
-          onPressed: () => {Get.to(() => const StartPage())},
-          disabled: !widget.isActive,
-        ));
   }
 }

--- a/lib/pages/onboarding/name_input.dart
+++ b/lib/pages/onboarding/name_input.dart
@@ -2,17 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:puppycode/pages/onboarding/start.dart';
 import 'package:puppycode/shared/styles/button.dart';
 import 'package:get/get.dart';
+import 'package:puppycode/shared/styles/color.dart';
 import 'package:puppycode/shared/typography/body.dart';
 import 'package:puppycode/shared/typography/head.dart';
 
-class NameInputPage extends StatefulWidget {
-  const NameInputPage({ super.key });
+class RegistrationPage extends StatefulWidget {
+  const RegistrationPage({super.key});
 
   @override
-  State<NameInputPage> createState() => _NameInputPageState();
+  State<RegistrationPage> createState() => _RegistrationPageState();
 }
 
-class _NameInputPageState extends State<NameInputPage> {
+class _RegistrationPageState extends State<RegistrationPage> {
   String name = '';
   bool isValidName = false;
 
@@ -22,8 +23,17 @@ class _NameInputPageState extends State<NameInputPage> {
     });
   }
 
+  _getInputBorderStyle(bool focus) {
+    return OutlineInputBorder(
+      borderSide:
+          BorderSide(color: focus ? ThemeColor.primary : ThemeColor.gray2),
+      borderRadius: BorderRadius.circular(20),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(),
@@ -40,14 +50,13 @@ class _NameInputPageState extends State<NameInputPage> {
                   validateName();
                 });
               },
-              decoration: const InputDecoration(
-                hintText: '개떡이',
-                focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.black),
-                ),
-                enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.grey),
-                ),
+              decoration: InputDecoration(
+                hintText: '강아지 이름',
+                focusedBorder: _getInputBorderStyle(true),
+                enabledBorder: _getInputBorderStyle(false),
+                contentPadding: const EdgeInsets.all(16),
+                labelStyle: BodyTextStyle.getBody1Style(bold: true),
+                hintStyle: BodyTextStyle.getBody1Style(color: ThemeColor.gray4),
               ),
             ),
           ],
@@ -85,14 +94,13 @@ class GuideText extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.fromLTRB(0, 0, 0, 64),
-      child: Column(
+      child: const Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Head2(value: '우리 집 강아지의 이름과\n사는 곳을 설정해 볼까요?'),
+          Head2(value: '우리 집 강아지의 이름과\n사는 곳을 설정해 볼까요?'),
           Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: Body2(
-                value: '키우는 강아지가 없어도 괜찮아요.', color: Color(0xFF50555C)),
+            padding: EdgeInsets.only(top: 8),
+            child: Body2(value: '키우는 강아지가 없어도 괜찮아요.', color: Color(0xFF50555C)),
           )
         ],
       ),

--- a/lib/pages/onboarding/register.dart
+++ b/lib/pages/onboarding/register.dart
@@ -30,6 +30,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
             TextInput(
               controller: _nameController,
               hintText: '강아지 이름',
+              maxLength: 10,
             ),
             const SizedBox(height: 12),
             // 지역 INPUT

--- a/lib/pages/onboarding/register.dart
+++ b/lib/pages/onboarding/register.dart
@@ -28,6 +28,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
           children: [
             const GuideText(),
             TextInput(
+              onChanged: (value) => {setState(() {})},
               controller: _nameController,
               hintText: '강아지 이름',
               maxLength: 10,

--- a/lib/pages/route.dart
+++ b/lib/pages/route.dart
@@ -10,7 +10,7 @@ class AppRoutes {
     GetPage(name: '/', page: () => const ScreenWithNavBar()),
     GetPage(name: '/settings', page: () => const SettingPage()),
     GetPage(name: '/onboarding', page: () => const LandingPage()),
-    GetPage(name: '/onboarding/name', page: () => const OnboardingPage()),
+    GetPage(name: '/onboarding/info', page: () => const OnboardingPage()),
     GetPage(name: '/create', page: () => const FeedWritePage()),
   ];
 }

--- a/lib/shared/input.dart
+++ b/lib/shared/input.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:puppycode/shared/styles/color.dart';
+import 'package:puppycode/shared/typography/body.dart';
+
+class TextInput extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final bool? showClearIcon; // icon asset path
+
+  const TextInput({
+    super.key,
+    required this.controller,
+    required this.hintText,
+    this.showClearIcon = true,
+  });
+
+  static _getInputBorderStyle(bool focus) {
+    return OutlineInputBorder(
+      borderSide:
+          BorderSide(color: focus ? ThemeColor.primary : ThemeColor.gray2),
+      borderRadius: BorderRadius.circular(20),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+          hintText: hintText,
+          focusedBorder: _getInputBorderStyle(true),
+          enabledBorder: _getInputBorderStyle(false),
+          contentPadding: const EdgeInsets.all(16),
+          labelStyle: BodyTextStyle.getBody1Style(bold: true),
+          hintStyle: BodyTextStyle.getBody1Style(color: ThemeColor.gray4),
+          suffixIcon: controller.text.isNotEmpty && showClearIcon == true
+              ? GestureDetector(
+                  onTap: () => {controller.clear()},
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: SvgPicture.asset(
+                      'assets/icons/clear.svg',
+                      width: 24,
+                      height: 24,
+                    ),
+                  ),
+                )
+              : null),
+    );
+  }
+}

--- a/lib/shared/input.dart
+++ b/lib/shared/input.dart
@@ -6,13 +6,15 @@ import 'package:puppycode/shared/typography/body.dart';
 class TextInput extends StatelessWidget {
   final TextEditingController controller;
   final String hintText;
-  final bool? showClearIcon; // icon asset path
+  final bool? showClearIcon;
+  final int? maxLength;
 
   const TextInput({
     super.key,
     required this.controller,
     required this.hintText,
     this.showClearIcon = true,
+    this.maxLength,
   });
 
   static _getInputBorderStyle(bool focus) {
@@ -26,8 +28,10 @@ class TextInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextField(
+      maxLength: maxLength,
       controller: controller,
       decoration: InputDecoration(
+          counterText: '',
           hintText: hintText,
           focusedBorder: _getInputBorderStyle(true),
           enabledBorder: _getInputBorderStyle(false),

--- a/lib/shared/input.dart
+++ b/lib/shared/input.dart
@@ -6,6 +6,7 @@ import 'package:puppycode/shared/typography/body.dart';
 class TextInput extends StatelessWidget {
   final TextEditingController controller;
   final String hintText;
+  final ValueChanged<String>? onChanged;
   final bool? showClearIcon;
   final int? maxLength;
 
@@ -13,6 +14,7 @@ class TextInput extends StatelessWidget {
     super.key,
     required this.controller,
     required this.hintText,
+    this.onChanged,
     this.showClearIcon = true,
     this.maxLength,
   });
@@ -28,6 +30,7 @@ class TextInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextField(
+      onChanged: (value) => {if (onChanged != null) onChanged!(value)},
       maxLength: maxLength,
       controller: controller,
       decoration: InputDecoration(
@@ -40,7 +43,10 @@ class TextInput extends StatelessWidget {
           hintStyle: BodyTextStyle.getBody1Style(color: ThemeColor.gray4),
           suffixIcon: controller.text.isNotEmpty && showClearIcon == true
               ? GestureDetector(
-                  onTap: () => {controller.clear()},
+                  onTap: () => {
+                    controller.clear(),
+                    if (onChanged != null) onChanged!('')
+                  },
                   child: Padding(
                     padding: const EdgeInsets.all(12),
                     child: SvgPicture.asset(

--- a/lib/shared/styles/button.dart
+++ b/lib/shared/styles/button.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:puppycode/shared/styles/color.dart';
 import 'package:puppycode/shared/typography/body.dart';
 
 class TextButtonColor extends WidgetStateColor {
   TextButtonColor() : super(defaultColor.value);
 
-  static Color defaultColor = const Color(0xFF36DBBF);
-  static Color pressedColor = const Color.fromARGB(255, 45, 170, 149); // 임시값
+  static Color defaultColor = ThemeColor.primary;
+  static Color pressedColor = ThemeColor.primaryPressed; // 임시값
 
   @override
   Color resolve(Set<WidgetState> states) {

--- a/lib/shared/styles/color.dart
+++ b/lib/shared/styles/color.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class ThemeColor {
+  static Color primary = const Color(0xFF36DBBF);
+  static Color primaryPressed = const Color(0xFF27AF98);
+
+  static Color white = const Color(0xFFFFFFFF);
+  static Color black = const Color(0xFF000000);
+
+  static Color gray1 = const Color(0xFFF9FAFB);
+  static Color gray2 = const Color(0xFFEFF2F5);
+  static Color gray3 = const Color(0xFFBFC9D0);
+  static Color gray4 = const Color(0xFF8D959A);
+  static Color gray5 = const Color(0xFF50555C);
+  static Color gray6 = const Color(0xFF1F1F20);
+}

--- a/lib/shared/typography/body.dart
+++ b/lib/shared/typography/body.dart
@@ -1,24 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:puppycode/shared/styles/color.dart';
 
-const _kDefaultTextColor = Color(0xFF1E2022);
+Color _kDefaultTextColor = ThemeColor.gray6;
 
 class Body1 extends StatelessWidget {
-  const Body1({super.key, required this.value, this.color});
+  const Body1({
+    super.key,
+    required this.value,
+    this.color,
+    this.bold = false,
+  });
 
   final Color? color;
   final String value;
+  final bool bold;
 
   @override
   Widget build(BuildContext context) {
     return Text(
       value,
-      style: TextStyle(
-        fontSize: 16,
-        fontWeight: FontWeight.w600,
-        letterSpacing: -1,
-        color: color ?? _kDefaultTextColor,
-        height: 22 / 16,
-      ),
+      style: BodyTextStyle.getBody1Style(color: color, bold: bold),
     );
   }
 }
@@ -39,13 +40,7 @@ class Body2 extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       value,
-      style: TextStyle(
-        fontSize: 15,
-        fontWeight: bold ? FontWeight.w600 : FontWeight.w400,
-        letterSpacing: -1,
-        color: color ?? _kDefaultTextColor,
-        height: 22 / 15,
-      ),
+      style: BodyTextStyle.getBody2Style(color: color, bold: bold),
     );
   }
 }
@@ -67,14 +62,41 @@ class Body4 extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       value,
-      style: TextStyle(
-        fontSize: 14,
-        fontWeight: bold ? FontWeight.w600 : FontWeight.w400,
-        letterSpacing: -1,
-        color: color ?? _kDefaultTextColor,
-        height: 18 / 14,
-        shadows: textShadow != null ? <Shadow>[textShadow!] : null,
-      ),
+      style: BodyTextStyle.getBody4Style(
+          color: color, bold: bold, textShadow: textShadow),
+    );
+  }
+}
+
+class BodyTextStyle {
+  static getBody1Style({Color? color, bool? bold}) {
+    return TextStyle(
+      fontSize: 16,
+      fontWeight: bold == true ? FontWeight.w600 : FontWeight.w400,
+      letterSpacing: -1,
+      color: color ?? _kDefaultTextColor,
+      height: 22 / 16,
+    );
+  }
+
+  static getBody2Style({Color? color, bool? bold}) {
+    return TextStyle(
+      fontSize: 15,
+      fontWeight: bold == true ? FontWeight.w600 : FontWeight.w400,
+      letterSpacing: -1,
+      color: color ?? _kDefaultTextColor,
+      height: 22 / 15,
+    );
+  }
+
+  static getBody4Style({Color? color, bool? bold, Shadow? textShadow}) {
+    return TextStyle(
+      fontSize: 14,
+      fontWeight: bold == true ? FontWeight.w600 : FontWeight.w400,
+      letterSpacing: -1,
+      color: color ?? _kDefaultTextColor,
+      height: 18 / 14,
+      shadows: textShadow != null ? <Shadow>[textShadow] : null,
     );
   }
 }

--- a/lib/shared/typography/body.dart
+++ b/lib/shared/typography/body.dart
@@ -24,10 +24,16 @@ class Body1 extends StatelessWidget {
 }
 
 class Body2 extends StatelessWidget {
-  const Body2({super.key, required this.value, this.color});
+  const Body2({
+    super.key,
+    required this.value,
+    this.color,
+    this.bold = false,
+  });
 
   final Color? color;
   final String value;
+  final bool bold;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +41,7 @@ class Body2 extends StatelessWidget {
       value,
       style: TextStyle(
         fontSize: 15,
-        fontWeight: FontWeight.w600,
+        fontWeight: bold ? FontWeight.w600 : FontWeight.w400,
         letterSpacing: -1,
         color: color ?? _kDefaultTextColor,
         height: 22 / 15,

--- a/lib/shared/typography/head.dart
+++ b/lib/shared/typography/head.dart
@@ -15,6 +15,21 @@ class Head1 extends StatelessWidget {
   }
 }
 
+class Head2 extends StatelessWidget {
+  const Head2({super.key, required this.value, this.color});
+
+  final Color? color;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      value,
+      style: HeadTextStyle.getH2Style(color: color),
+    );
+  }
+}
+
 class Head3 extends StatelessWidget {
   const Head3({super.key, required this.value, this.color});
 
@@ -40,6 +55,16 @@ class HeadTextStyle {
       letterSpacing: -1.2,
       color: color ?? _kDefaultTextColor,
       height: 32 / 24,
+    );
+  }
+
+  static getH2Style({Color? color}) {
+    return TextStyle(
+      fontSize: 22,
+      fontWeight: FontWeight.w700,
+      letterSpacing: -1.2,
+      color: color ?? _kDefaultTextColor,
+      height: 31 / 22,
     );
   }
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:puppycode/pages/route.dart';
+import 'package:puppycode/shared/styles/color.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -10,14 +11,14 @@ class MyApp extends StatelessWidget {
     return GetMaterialApp(
       theme: ThemeData(
         fontFamily: 'Pretendard',
-        scaffoldBackgroundColor: Colors.white,
-        appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
+          scaffoldBackgroundColor: ThemeColor.white,
+          appBarTheme: AppBarTheme(backgroundColor: ThemeColor.white),
           bottomNavigationBarTheme:
-              const BottomNavigationBarThemeData(backgroundColor: Colors.white),
-          floatingActionButtonTheme: const FloatingActionButtonThemeData(
-              backgroundColor: Color(0xFF36DBBF)),
+              BottomNavigationBarThemeData(backgroundColor: ThemeColor.white),
+          floatingActionButtonTheme: FloatingActionButtonThemeData(
+              backgroundColor: ThemeColor.primary),
         bottomSheetTheme:
-            const BottomSheetThemeData(backgroundColor: Colors.white),
+              BottomSheetThemeData(backgroundColor: ThemeColor.white),
           inputDecorationTheme: const InputDecorationTheme(
             border: InputBorder.none,
             focusedBorder: InputBorder.none,
@@ -26,7 +27,7 @@ class MyApp extends StatelessWidget {
             disabledBorder: InputBorder.none,
           )
       ),
-      initialRoute: '/',
+      initialRoute: '/onboarding/info',
       getPages: AppRoutes.routes,
     );
   }


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 온보딩 디자인이 많이 바꼈다.. 이름 인풋을 추가했음. > 이때 shared로 분리함 (어디서 또 쓰일지는 모르겠음 ㅎ)
  - suffixIcon 기능이 있다 생각보다 플러터는 이게 돼? 이게 왜 안돼? 반복이구나
- 디자인에서 정리한 컬러들을 static 값들로 관리하게 했다. Theme에 넣을까 했는데.. 흠 생각보다 복잡하고 뭔가 내가 원하는 이름으로 쓰기 번거로운 것 같아서 ThemeColor를 그대로 가져오게 했음. (우린 머 다크모드 없으니 일단 상관없을듯)

### route
<!-- ex /home -->
- onboarding/name > onboarding/info 로 변경함

### 스크린샷

<img src="https://github.com/user-attachments/assets/f878f726-68b2-4765-9b06-7ce793e306b2" width="400">
