### PR TITLE
수정된 카메라 UI 반영 + 촬영 완료 페이지 연결

### DIFF
--- a/assets/icons/camera_button.svg
+++ b/assets/icons/camera_button.svg
@@ -1,0 +1,4 @@
+<svg width="81" height="80" viewBox="0 0 81 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40.5" cy="40" r="37" stroke="white" stroke-width="6"/>
+<circle cx="40.5" cy="40" r="28" fill="white"/>
+</svg>

--- a/assets/icons/camera_complete.svg
+++ b/assets/icons/camera_complete.svg
@@ -1,0 +1,5 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#36DBBF"/>
+<rect width="48" height="48" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 16 64)" fill="#36DBBF"/>
+<path d="M53 32.5L37.0254 48.5L26.6 38" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/camera_flip.svg
+++ b/assets/icons/camera_flip.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M36 27.7647C34.3978 32.5376 29.6315 36 24 36C18.3697 36 13.6022 32.5376 12 27.7647V34.8235M36 12.1765V19.2353C34.3978 14.4624 29.6315 11 24 11C18.3697 11 13.6022 14.4624 12 19.2353" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/close.svg
+++ b/assets/icons/close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 5L19 19" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M5 18.9998L18.9998 4.99995" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/lib/pages/feeds/photo_preview.dart
+++ b/lib/pages/feeds/photo_preview.dart
@@ -59,6 +59,7 @@ class PhotoPreviewPage extends StatelessWidget {
                     ),
                   ),
                   GestureDetector(
+                    onTap: () => {Get.toNamed('/create')},
                     child: SvgPicture.asset('assets/icons/camera_complete.svg'),
                   ),
                   const SizedBox(

--- a/lib/pages/feeds/photo_preview.dart
+++ b/lib/pages/feeds/photo_preview.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
+import 'package:puppycode/shared/styles/color.dart';
+import 'package:puppycode/shared/typography/body.dart';
+
+class PhotoPreviewPage extends StatelessWidget {
+  const PhotoPreviewPage({super.key, required this.imagePath});
+
+  final String imagePath;
+  //final bool isSquare;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        color: Colors.black,
+        child: Stack(alignment: Alignment.center, children: [
+          Container(
+            margin: const EdgeInsets.only(bottom: 48),
+            child: AspectRatio(
+              aspectRatio: 0.75,
+              child: ClipRRect(
+                  borderRadius: BorderRadius.circular(20),
+                  child: FittedBox(
+                    fit: BoxFit.fitWidth,
+                    child: Image.file(File(imagePath)),
+                  )),
+            ),
+          ),
+          Positioned(
+              top: 15,
+              child: Body1(
+                value: '산책 기록하기',
+                color: ThemeColor.white,
+                bold: true,
+              )),
+          Positioned(
+            bottom: 20,
+            left: 0,
+            right: 0,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 40),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  GestureDetector(
+                    onTap: () => {Get.back()},
+                    child: SizedBox(
+                      width: 40,
+                      height: 40,
+                      child: SvgPicture.asset(
+                        'assets/icons/close.svg',
+                        width: 40,
+                        height: 40,
+                      ),
+                    ),
+                  ),
+                  GestureDetector(
+                    child: SvgPicture.asset('assets/icons/camera_complete.svg'),
+                  ),
+                  const SizedBox(
+                    width: 40,
+                    height: 40,
+                  )
+                ],
+              ),
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/pages/route.dart
+++ b/lib/pages/route.dart
@@ -3,6 +3,7 @@ import 'package:puppycode/pages/onboarding/index.dart';
 import 'package:puppycode/pages/onboarding/landing.dart';
 import 'package:puppycode/pages/feeds/write.dart';
 import 'package:puppycode/pages/setting.dart';
+import 'package:puppycode/shared/camera.dart';
 import 'package:puppycode/shared/nav_bar.dart';
 
 class AppRoutes {
@@ -12,5 +13,9 @@ class AppRoutes {
     GetPage(name: '/onboarding', page: () => const LandingPage()),
     GetPage(name: '/onboarding/info', page: () => const OnboardingPage()),
     GetPage(name: '/create', page: () => const FeedWritePage()),
+    GetPage(
+        name: '/camera',
+        page: () => const CameraScreen(),
+        transition: Transition.downToUp),
   ];
 }

--- a/lib/shared/camera.dart
+++ b/lib/shared/camera.dart
@@ -1,7 +1,9 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
+import 'package:puppycode/shared/styles/color.dart';
 
 class CameraScreen extends StatefulWidget {
   const CameraScreen({super.key});
@@ -10,10 +12,13 @@ class CameraScreen extends StatefulWidget {
   State<CameraScreen> createState() => CameraScreenState();
 }
 
+enum CameraRatio { square, rectangle }
+
 class CameraScreenState extends State<CameraScreen>
     with WidgetsBindingObserver {
   CameraController? _controller;
   bool _isCameraInitialized = false;
+  CameraRatio _cameraRatio = CameraRatio.rectangle;
   late final List<CameraDescription> _cameras;
 
   get camera => CameraDescription;
@@ -85,6 +90,14 @@ class CameraScreenState extends State<CameraScreen>
     }
   }
 
+  void _changeCameraRatio() {
+    setState(() {
+      _cameraRatio = _cameraRatio == CameraRatio.rectangle
+          ? CameraRatio.square
+          : CameraRatio.rectangle;
+    });
+  }
+
   void _takePhoto() async {
     //final navigator = Navigator.of(context);
     final xFile = await capturePhoto();
@@ -112,79 +125,107 @@ class CameraScreenState extends State<CameraScreen>
   @override
   Widget build(BuildContext context) {
     if (_isCameraInitialized) {
-      return Container(
-        color: Colors.black,
-        child: Stack(children: [
-          Container(
-            margin: const EdgeInsets.only(top: 120),
-            child: AspectRatio(
-              aspectRatio: 0.75,
-              child: ClipRect(
-                  child: FittedBox(
-                fit: BoxFit.fitWidth,
-                child: SizedBox(
-                  width: _controller!.value.previewSize!.height,
-                  height: _controller!.value.previewSize!.width,
-                  child: CameraPreview(_controller!),
-                ),
-              )),
-            ),
-          ),
-          Positioned(
-            top: 55,
-            left: 20,
-            child: IconButton(
-              icon: const Icon(Icons.flash_off, color: Colors.white, size: 25),
-              onPressed: () {
-                // 플래시 토글 기능 추가
-              },
-            ),
-          ),
-          Positioned(
-            bottom: 70,
-            left: 0,
-            right: 0,
-            child: Container(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  TextButton(
-                    child: const Text(
-                      '취소',
-                      style: TextStyle(fontSize: 18, color: Colors.white),
-                    ),
-                    onPressed: () {
-                      dispose();
-                      Get.back();
-                    },
-                  ),
-                  const SizedBox(width: 80),
-                  GestureDetector(
-                    onTap: () {
-                      _takePhoto();
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.all(20),
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        border: Border.all(color: Colors.white, width: 4),
+      return SafeArea(
+        child: Container(
+          color: Colors.black,
+          child: Stack(alignment: Alignment.center, children: [
+            Container(
+              margin: EdgeInsets.only(
+                  bottom: _cameraRatio == CameraRatio.rectangle ? 48 : 126),
+              child: AspectRatio(
+                aspectRatio: _cameraRatio == CameraRatio.rectangle ? 0.75 : 1,
+                child: ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    child: FittedBox(
+                      fit: BoxFit.fitWidth,
+                      child: SizedBox(
+                        width: _controller?.value.previewSize!.height,
+                        height: _controller?.value.previewSize!.width,
+                        child: _controller != null
+                            ? CameraPreview(_controller!)
+                            : null,
                       ),
-                    ),
-                  ),
-                  const SizedBox(width: 80),
-                  IconButton(
-                    icon: const Icon(Icons.cameraswitch,
-                        color: Colors.white, size: 30),
-                    onPressed: () {
-                      // FIXME flip resume될 때만 되는 이슈
-                      _flipCameraDirection();
-                    },
-                  ),
-                ],
+                    )),
               ),
             ),
-          ),
-        ]),
+            Positioned(
+              top: 15,
+              left: 20,
+              child: GestureDetector(
+                onTap: () {
+                  dispose();
+                  Get.back();
+                },
+                child: IconButton(
+                  icon: SvgPicture.asset('assets/icons/close.svg'),
+                  onPressed: () {
+                    // 플래시 토글 기능 추가
+                  },
+                ),
+              ),
+            ),
+            Positioned(
+              top: 88 + 458,
+              child: GestureDetector(
+                onTap: () => {_changeCameraRatio()},
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20),
+                      color: ThemeColor.white.withOpacity(0.15)),
+                  child: Text(
+                    _cameraRatio == CameraRatio.rectangle ? '3:4' : '1:1',
+                    style: TextStyle(
+                      decoration: TextDecoration.none,
+                      color: ThemeColor.white,
+                      fontSize: 17,
+                      fontWeight: FontWeight.w400,
+                      height: 22 / 17,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: 20,
+              left: 0,
+              right: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 40),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    SizedBox(
+                      width: 40,
+                      height: 40,
+                      child: Container(
+                        color: Colors.yellow,
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        _takePhoto();
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.all(20),
+                        child:
+                            SvgPicture.asset('assets/icons/camera_button.svg'),
+                      ),
+                    ),
+                    GestureDetector(
+                      child: SvgPicture.asset('assets/icons/camera_flip.svg'),
+                      onTap: () {
+                        // FIXME flip resume될 때만 되는 이슈
+                        _flipCameraDirection();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ]),
+        ),
       );
     } else {
       return const Center(

--- a/lib/shared/camera.dart
+++ b/lib/shared/camera.dart
@@ -3,7 +3,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
+import 'package:puppycode/pages/feeds/photo_preview.dart';
 import 'package:puppycode/shared/styles/color.dart';
+import 'package:puppycode/shared/typography/body.dart';
 
 class CameraScreen extends StatefulWidget {
   const CameraScreen({super.key});
@@ -99,19 +101,11 @@ class CameraScreenState extends State<CameraScreen>
   }
 
   void _takePhoto() async {
-    //final navigator = Navigator.of(context);
     final xFile = await capturePhoto();
     if (xFile != null) {
-      //print(xFile.toString());
-      //if (xFile.path.isNotEmpty) {
-      //  navigator.push(
-      //    MaterialPageRoute(
-      //      builder: (context) => PreviewPage(
-      //        imagePath: xFile.path,
-      //      ),
-      //    ),
-      //  );
-      //}
+      if (xFile.path.isNotEmpty) {
+        Get.to(() => PhotoPreviewPage(imagePath: xFile.path));
+      }
     }
   }
 
@@ -174,15 +168,11 @@ class CameraScreenState extends State<CameraScreen>
                   decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(20),
                       color: ThemeColor.white.withOpacity(0.15)),
-                  child: Text(
-                    _cameraRatio == CameraRatio.rectangle ? '3:4' : '1:1',
-                    style: TextStyle(
-                      decoration: TextDecoration.none,
-                      color: ThemeColor.white,
-                      fontSize: 17,
-                      fontWeight: FontWeight.w400,
-                      height: 22 / 17,
-                    ),
+                  child: Body1(
+                    value:
+                        _cameraRatio == CameraRatio.rectangle ? '3:4' : '1:1',
+                    bold: true,
+                    color: ThemeColor.white,
                   ),
                 ),
               ),
@@ -207,11 +197,7 @@ class CameraScreenState extends State<CameraScreen>
                       onTap: () {
                         _takePhoto();
                       },
-                      child: Container(
-                        padding: const EdgeInsets.all(20),
-                        child:
-                            SvgPicture.asset('assets/icons/camera_button.svg'),
-                      ),
+                      child: SvgPicture.asset('assets/icons/camera_button.svg'),
                     ),
                     GestureDetector(
                       child: SvgPicture.asset('assets/icons/camera_flip.svg'),

--- a/lib/shared/camera.dart
+++ b/lib/shared/camera.dart
@@ -150,12 +150,7 @@ class CameraScreenState extends State<CameraScreen>
                   dispose();
                   Get.back();
                 },
-                child: IconButton(
-                  icon: SvgPicture.asset('assets/icons/close.svg'),
-                  onPressed: () {
-                    // 플래시 토글 기능 추가
-                  },
-                ),
+                child: SvgPicture.asset('assets/icons/close.svg'),
               ),
             ),
             Positioned(

--- a/lib/shared/camera.dart
+++ b/lib/shared/camera.dart
@@ -14,13 +14,10 @@ class CameraScreen extends StatefulWidget {
   State<CameraScreen> createState() => CameraScreenState();
 }
 
-enum CameraRatio { square, rectangle }
-
 class CameraScreenState extends State<CameraScreen>
     with WidgetsBindingObserver {
   CameraController? _controller;
   bool _isCameraInitialized = false;
-  CameraRatio _cameraRatio = CameraRatio.rectangle;
   late final List<CameraDescription> _cameras;
 
   get camera => CameraDescription;
@@ -92,14 +89,6 @@ class CameraScreenState extends State<CameraScreen>
     }
   }
 
-  void _changeCameraRatio() {
-    setState(() {
-      _cameraRatio = _cameraRatio == CameraRatio.rectangle
-          ? CameraRatio.square
-          : CameraRatio.rectangle;
-    });
-  }
-
   void _takePhoto() async {
     final xFile = await capturePhoto();
     if (xFile != null) {
@@ -124,10 +113,9 @@ class CameraScreenState extends State<CameraScreen>
           color: Colors.black,
           child: Stack(alignment: Alignment.center, children: [
             Container(
-              margin: EdgeInsets.only(
-                  bottom: _cameraRatio == CameraRatio.rectangle ? 48 : 126),
+              margin: const EdgeInsets.only(bottom: 48),
               child: AspectRatio(
-                aspectRatio: _cameraRatio == CameraRatio.rectangle ? 0.75 : 1,
+                aspectRatio: 0.75,
                 child: ClipRRect(
                     borderRadius: BorderRadius.circular(20),
                     child: FittedBox(
@@ -151,25 +139,6 @@ class CameraScreenState extends State<CameraScreen>
                   Get.back();
                 },
                 child: SvgPicture.asset('assets/icons/close.svg'),
-              ),
-            ),
-            Positioned(
-              top: 88 + 458,
-              child: GestureDetector(
-                onTap: () => {_changeCameraRatio()},
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),
-                      color: ThemeColor.white.withOpacity(0.15)),
-                  child: Body1(
-                    value:
-                        _cameraRatio == CameraRatio.rectangle ? '3:4' : '1:1',
-                    bold: true,
-                    color: ThemeColor.white,
-                  ),
-                ),
               ),
             ),
             Positioned(

--- a/lib/shared/nav_bar.dart
+++ b/lib/shared/nav_bar.dart
@@ -99,12 +99,12 @@ class WriteFloatingButton extends StatelessWidget {
 
   _onButtonClick(bool hasWritten) {
     if (hasWritten) return;
-    Get.toNamed('/create');
+    Get.toNamed('/camera');
   }
 
   @override
   Widget build(BuildContext context) {
-    var hasWritten = true;
+    var hasWritten = false;
     var floatingButtonColor =
         Theme.of(context).floatingActionButtonTheme.backgroundColor;
 

--- a/lib/shared/typography/body.dart
+++ b/lib/shared/typography/body.dart
@@ -76,6 +76,7 @@ class BodyTextStyle {
       letterSpacing: -1,
       color: color ?? _kDefaultTextColor,
       height: 22 / 16,
+      decoration: TextDecoration.none,
     );
   }
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
             disabledBorder: InputBorder.none,
           )
       ),
-      initialRoute: '/onboarding/info',
+      initialRoute: '/',
       getPages: AppRoutes.routes,
     );
   }


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 카메라 UI 디자인 수정된 거 반영
- 카메라 스크린과 작성페이지 사이에 있는 사진 확인 페이지 추가
- ratio (정방형, 4:3) 변경하는 기능도 일단 추가는 했는데 crop.. 하고 피드 ui도 바껴야 해서 일단 4:3만 하는 걸로 디자인쪽에 얘기중 ㅠㅠ

### route
<!-- ex /home -->
- /camera
- flow: feed -> CameraScreen -> PhotoPreview -> Write (/create)

### 스크린샷

![RPReplay_Final1723131283-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0233e0ce-fdfc-438c-b412-779f15e63257)

